### PR TITLE
Execute custom user script before the compile step

### DIFF
--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -67,6 +67,12 @@ if [ "$FLAG_V" == "true" ]; then V=-v; fi
 if [ "$FLAG_X" == "true" ]; then X=-x; fi
 if [ "$FLAG_RACE" == "true" ]; then R=-race; fi
 
+if [ -n $BEFORE_BUILD ]; then
+	chmod +x /scripts/$BEFORE_BUILD
+	echo "Execute /scripts/$BEFORE_BUILD"
+	/scripts/$BEFORE_BUILD
+fi
+
 # If no build targets were specified, inject a catch all wildcard
 if [ "$TARGETS" == "" ]; then
   TARGETS="./."


### PR DESCRIPTION
Another PR in the direction of extensibility, not sure if this fits with the project's goals. It adds a `-before-build` parameter which accepts a script which will be executed after cloning but before running the compilers.

This can be used, for example, to get and compile dependencies for which the steps taken by the `build_deps.sh` script are not enough.
