### PR TITLE
fix: change Android builds to explicitly target Java 1.7 as 1.8 is no…

### DIFF
--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -289,7 +289,7 @@ for TARGET in $TARGETS; do
 
         # Compile the Java wrapper and assemble into a .jar file
         mkdir -p $jni/build
-        javac -cp . -d $jni/build $jni/${package//.//}/*.java
+        javac -target 1.7 -source 1.7 -cp . -d $jni/build $jni/${package//.//}/*.java
         (cd $jni/build && jar cvf $archive/classes.jar *)
 
         # Finally assemble the archive contents into an .aar and clean up


### PR DESCRIPTION
…t yet supported

1.8 support is coming in Android N.

Closes #53

References:
http://android-developers.blogspot.com.au/2016/03/first-preview-of-android-n-developer.html