### PR TITLE
Add latest go version with missing go version

### DIFF
--- a/docker/go-1.10.0/Dockerfile
+++ b/docker/go-1.10.0/Dockerfile
@@ -1,4 +1,4 @@
-# Go cross compiler (xgo): Go 1.10
+# Go cross compiler (xgo): Go 1.10.0
 # Copyright (c) 2017 Péter Szilágyi. All rights reserved.
 #
 # Released under the MIT license.
@@ -8,7 +8,7 @@ FROM karalabe/xgo-base
 MAINTAINER Péter Szilágyi <peterke@gmail.com>
 
 # Configure the root Go distribution and bootstrap based on it
-ENV GO_VERSION 110
+ENV GO_VERSION 1100
 
 RUN \
   export ROOT_DIST=https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz     && \

--- a/docker/go-1.10.x/Dockerfile
+++ b/docker/go-1.10.x/Dockerfile
@@ -1,8 +1,8 @@
-# Go cross compiler (xgo): Wildcard layer to the latest Go release
+# Go cross compiler (xgo): Go 1.10.x
 # Copyright (c) 2017 Péter Szilágyi. All rights reserved.
 #
 # Released under the MIT license.
 
-FROM karalabe/xgo-1.10.x
+FROM karalabe/xgo-1.10.0
 
 MAINTAINER Péter Szilágyi <peterke@gmail.com>

--- a/docker/go-1.10/Dockerfile
+++ b/docker/go-1.10/Dockerfile
@@ -1,0 +1,17 @@
+# Go cross compiler (xgo): Go 1.10
+# Copyright (c) 2017 Péter Szilágyi. All rights reserved.
+#
+# Released under the MIT license.
+
+FROM karalabe/xgo-base
+
+MAINTAINER Péter Szilágyi <peterke@gmail.com>
+
+# Configure the root Go distribution and bootstrap based on it
+ENV GO_VERSION 110
+
+RUN \
+  export ROOT_DIST=https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz     && \
+  export ROOT_DIST_SHA=b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33 && \
+  \
+  $BOOTSTRAP_PURE

--- a/docker/go-1.9.3/Dockerfile
+++ b/docker/go-1.9.3/Dockerfile
@@ -1,0 +1,17 @@
+# Go cross compiler (xgo): Go 1.9.2
+# Copyright (c) 2017 Péter Szilágyi. All rights reserved.
+#
+# Released under the MIT license.
+
+FROM karalabe/xgo-base
+
+MAINTAINER Péter Szilágyi <peterke@gmail.com>
+
+# Configure the root Go distribution and bootstrap based on it
+ENV GO_VERSION 193
+
+RUN \
+  export ROOT_DIST=https://storage.googleapis.com/golang/go1.9.3.linux-amd64.tar.gz     && \
+  export ROOT_DIST_SHA=a4da5f4c07dfda8194c4621611aeb7ceaab98af0b38bfb29e1be2ebb04c3556c && \
+  \
+  $BOOTSTRAP_PURE

--- a/docker/go-1.9.4/Dockerfile
+++ b/docker/go-1.9.4/Dockerfile
@@ -1,0 +1,17 @@
+# Go cross compiler (xgo): Go 1.9.2
+# Copyright (c) 2017 Péter Szilágyi. All rights reserved.
+#
+# Released under the MIT license.
+
+FROM karalabe/xgo-base
+
+MAINTAINER Péter Szilágyi <peterke@gmail.com>
+
+# Configure the root Go distribution and bootstrap based on it
+ENV GO_VERSION 194
+
+RUN \
+  export ROOT_DIST=https://storage.googleapis.com/golang/go1.9.4.linux-amd64.tar.gz     && \
+  export ROOT_DIST_SHA=15b0937615809f87321a457bb1265f946f9f6e736c563d6c5e0bd2c22e44f779 && \
+  \
+  $BOOTSTRAP_PURE

--- a/docker/go-1.9.x/Dockerfile
+++ b/docker/go-1.9.x/Dockerfile
@@ -3,6 +3,6 @@
 #
 # Released under the MIT license.
 
-FROM karalabe/xgo-1.9.2
+FROM karalabe/xgo-1.9.4
 
 MAINTAINER Péter Szilágyi <peterke@gmail.com>

--- a/docker/go-latest/Dockerfile
+++ b/docker/go-latest/Dockerfile
@@ -3,6 +3,6 @@
 #
 # Released under the MIT license.
 
-FROM karalabe/xgo-1.10
+FROM karalabe/xgo-1.10.0
 
 MAINTAINER Péter Szilágyi <peterke@gmail.com>

--- a/docker/go-latest/Dockerfile
+++ b/docker/go-latest/Dockerfile
@@ -3,6 +3,6 @@
 #
 # Released under the MIT license.
 
-FROM karalabe/xgo-1.9.x
+FROM karalabe/xgo-1.10
 
 MAINTAINER Péter Szilágyi <peterke@gmail.com>


### PR DESCRIPTION
Added
- 1.9.3
- 1.9.4
- 1.9.x to 1.9.4
- 1.10 and change go-latest to 1.10

Those will fixed #103 #99 