### PR TITLE
Fix $GOPATH mounting on Windows for local builds

### DIFF
--- a/xgo.go
+++ b/xgo.go
@@ -269,13 +269,13 @@ func compile(image string, config *ConfigFlags, flags *BuildFlags, folder string
 				// Folder needs explicit mounting due to docker symlink security
 				locals = append(locals, target)
 				mounts = append(mounts, filepath.Join("/ext-go", strconv.Itoa(len(locals)), "src", strings.TrimPrefix(path, sources)))
-				paths = append(paths, filepath.Join("/ext-go", strconv.Itoa(len(locals))))
+				paths = append(paths, filepath.ToSlash(filepath.Join("/ext-go", strconv.Itoa(len(locals)))))
 				return nil
 			})
 			// Export the main mount point for this GOPATH entry
 			locals = append(locals, sources)
 			mounts = append(mounts, filepath.Join("/ext-go", strconv.Itoa(len(locals)), "src"))
-			paths = append(paths, filepath.Join("/ext-go", strconv.Itoa(len(locals))))
+			paths = append(paths, filepath.ToSlash(filepath.Join("/ext-go", strconv.Itoa(len(locals)))))
 		}
 	}
 	// Assemble and run the cross compilation command


### PR DESCRIPTION
Resolves https://github.com/karalabe/xgo/issues/115

The `EXT_GOPATH` value used inside the xgo docker [build script](https://github.com/karalabe/xgo/blob/master/docker/base/build.sh#L53) requires Linux file separators. If `xgo` was used on Windows and built using a local build, the `EXT_GOPATH` argument would forward along a Windows-style path.

This patch forwards along the path with the proper Linux file separators regardless of the `os.PathSeparator` value.

Before: `EXT_GOPATH=\ext-go\1`
After: `EXT_GOPATH=/ext-go/1`