### PR TITLE
add go 1.10.2 and 1.10.3

### DIFF
--- a/docker/go-1.10.2/Dockerfile
+++ b/docker/go-1.10.2/Dockerfile
@@ -1,0 +1,17 @@
+# Go cross compiler (xgo): Go 1.10
+# Copyright (c) 2018 Péter Szilágyi. All rights reserved.
+#
+# Released under the MIT license.
+
+FROM karalabe/xgo-base
+
+MAINTAINER Péter Szilágyi <peterke@gmail.com>
+
+# Configure the root Go distribution and bootstrap based on it
+ENV GO_VERSION 1102
+
+RUN \
+  export ROOT_DIST=https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz    && \
+  export ROOT_DIST_SHA=4b677d698c65370afa33757b6954ade60347aaca310ea92a63ed717d7cb0c2ff && \
+  \
+  $BOOTSTRAP_PURE

--- a/docker/go-1.10.3/Dockerfile
+++ b/docker/go-1.10.3/Dockerfile
@@ -1,0 +1,17 @@
+# Go cross compiler (xgo): Go 1.10
+# Copyright (c) 2018 Péter Szilágyi. All rights reserved.
+#
+# Released under the MIT license.
+
+FROM karalabe/xgo-base
+
+MAINTAINER Péter Szilágyi <peterke@gmail.com>
+
+# Configure the root Go distribution and bootstrap based on it
+ENV GO_VERSION 1103
+
+RUN \
+  export ROOT_DIST=https://storage.googleapis.com/golang/go1.10.3.linux-amd64.tar.gz    && \
+  export ROOT_DIST_SHA=fa1b0e45d3b647c252f51f5e1204aba049cde4af177ef9f2181f43004f901035 && \
+  \
+  $BOOTSTRAP_PURE

--- a/docker/go-1.10.x/Dockerfile
+++ b/docker/go-1.10.x/Dockerfile
@@ -3,6 +3,6 @@
 #
 # Released under the MIT license.
 
-FROM karalabe/xgo-1.10.1
+FROM karalabe/xgo-1.10.3
 
 MAINTAINER Péter Szilágyi <peterke@gmail.com>


### PR DESCRIPTION
This extends #122, making 1.10.3 the default version of Go used.