### PR TITLE
Call chown on built artifacts to the correct owner after build. Closes #37

### DIFF
--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -46,7 +46,7 @@ function extension {
   fi
 }
 
-# Either set a local build environemnt, or pull any remote imports
+# Either set a local build environment, or pull any remote imports
 if [ "$EXT_GOPATH" != "" ]; then
   # If local builds are requested, inject the sources
   echo "Building locally $1..."
@@ -296,6 +296,9 @@ for TARGET in $TARGETS; do
         (cd $archive && zip -r $bundle *)
         rm -rf $jni $archive
       fi
+
+      # Fix up permissions on bundle file
+      chown $UID:$GID $bundle
     fi
     # Clean up the android builds, toolchains and runtimes
     rm -rf /build-android-aar
@@ -600,6 +603,8 @@ for TARGET in $TARGETS; do
         echo -e "framework module \"$title\" {\n  header \"$title.h\"\n  export *\n}" > $framework/Versions/A/Modules/module.modulemap
         (cd $framework && ln -nsf Versions/A/Modules Modules)
 
+        # Fix up permissions on bundle file
+        chown $UID:$GID /build/$NAME-ios-$PLATFORM-framework
         chmod 777 -R /build/$NAME-ios-$PLATFORM-framework
       fi
       rm -rf /build-ios-fw

--- a/xgo.go
+++ b/xgo.go
@@ -299,6 +299,12 @@ func compile(image string, config *ConfigFlags, flags *BuildFlags, folder string
 		"-e", fmt.Sprintf("FLAG_BUILDMODE=%s", flags.Mode),
 		"-e", "TARGETS=" + strings.Replace(strings.Join(config.Targets, " "), "*", ".", -1),
 	}
+	user, err := user.Current()
+	if err == nil {
+		args = append(args,
+			"-e", fmt.Sprintf("UID=%s", user.Uid),
+			"-e", fmt.Sprintf("GID=%s", user.Gid))
+	}
 	for i := 0; i < len(locals); i++ {
 		args = append(args, []string{"-v", fmt.Sprintf("%s:%s:ro", locals[i], mounts[i])}...)
 	}


### PR DESCRIPTION
This PR makes the necessary changes so that the docker image can run as non-root (it will use the host UID). Avoids having files be created on host as `root`. To avoid any issues, the output folder should have been precreated by the caller of `xgo`.

Closes #37