### PR TITLE
build.sh doc

### DIFF
--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -19,7 +19,7 @@
 #   FLAG_TAGS      - Optional tag flag to set on the Go builder
 #   FLAG_LDFLAGS   - Optional ldflags flag to set on the Go builder
 #   FLAG_BUILDMODE - Optional buildmode flag to set on the Go builder
-#   TARGETS        - Comma separated list of build targets to compile for
+#   TARGETS        - Space separated list of build targets to compile for
 #   GO_VERSION     - Bootstrapped version of Go to disable uncupported targets
 #   EXT_GOPATH     - GOPATH elements mounted from the host filesystem
 


### PR DESCRIPTION
Looks like a comma separated list of target doesn't work but space do. In xgo.go space is used in strings.Join.