### PR TITLE
Ensure time preservation in handling of deps source

### DIFF
--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -117,9 +117,9 @@ fi
 # Download all the C dependencies
 mkdir /deps
 DEPS=($DEPS) && for dep in "${DEPS[@]}"; do
-  if [ "${dep##*.}" == "tar" ]; then cat "/deps-cache/`basename $dep`" | tar -C /deps -x; fi
-  if [ "${dep##*.}" == "gz" ];  then cat "/deps-cache/`basename $dep`" | tar -C /deps -xz; fi
-  if [ "${dep##*.}" == "bz2" ]; then cat "/deps-cache/`basename $dep`" | tar -C /deps -xj; fi
+  if [ "${dep##*.}" == "tar" ]; then cat "/deps-cache/`basename $dep`" | tar -C /deps -x --atime-preserve; fi
+  if [ "${dep##*.}" == "gz" ];  then cat "/deps-cache/`basename $dep`" | tar -C /deps -xz --atime-preserve; fi
+  if [ "${dep##*.}" == "bz2" ]; then cat "/deps-cache/`basename $dep`" | tar -C /deps -xj --atime-preserve; fi
 done
 
 DEPS_ARGS=($ARGS)

--- a/docker/base/build_deps.sh
+++ b/docker/base/build_deps.sh
@@ -12,7 +12,7 @@
 set -e
 
 # Remove any previous build leftovers, and copy a fresh working set (clean doesn't work for cross compiling)
-rm -rf /deps-build && cp -r $1 /deps-build
+rm -rf /deps-build && cp -rp $1 /deps-build
 
 # Build all the dependencies (no order for now)
 for dep in `ls /deps-build`; do


### PR DESCRIPTION
When building dependencies, if timestamps have changed on the files, at least sometimes aclocal and automake will start working. That can be a problem if there is a version mismatch on automake in the Docker image and what was originally used in the dependency. 

Then a full new autoreconf is needed, but that require a lot of new logic to handle. 

This pull request instead ensures that the timestamps is preserved when unpacking and copying the files 